### PR TITLE
fix: add fallback for undefined git ref

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -1,4 +1,4 @@
-const gitRef = process.env.GITHUB_REF
+const gitRef = process.env.GITHUB_REF || ''
 
 // By default, the version number is the GH Actions build number
 // This will not change if you re-run an exact build.


### PR DESCRIPTION
the project currently can't be run locally since it assumes it's running from the CI of the builder repo; having a fallback let's you test it directly without needing to run an action