### PR TITLE
fix: update electron to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1568,20 +1568,20 @@
       }
     },
     "electron": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-9.2.1.tgz",
-      "integrity": "sha512-ZsetaQjXB8+9/EFW1FnfK4ukpkwXCxMEaiKiUZhZ0ZLFlLnFCpe0Bg4vdDf7e4boWGcnlgN1jAJpBw7w0eXuqA==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-13.1.1.tgz",
+      "integrity": "sha512-kySSb5CbIkWU2Kd9mf2rpGZC9p1nWhVVNl+CJjuOUGeVPXHbojHvTkDU1iC8AvV28eik3gqHisSJss40Caprog==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.0.1",
-        "@types/node": "^12.0.12",
+        "@types/node": "^14.6.2",
         "extract-zip": "^1.0.3"
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.12.54",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.54.tgz",
-          "integrity": "sha512-ge4xZ3vSBornVYlDnk7yZ0gK6ChHf/CHB7Gl1I0Jhah8DDnEQqBzgohYG4FX4p81TNirSETOiSyn+y1r9/IR6w==",
+          "version": "14.17.2",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.2.tgz",
+          "integrity": "sha512-sld7b/xmFum66AAKuz/rp/CUO8+98fMpyQ3SBfzzBNGMd/1iHBTAg9oyAvcYlAj46bpc74r91jSw2iFdnx29nw==",
           "dev": true
         },
         "debug": {
@@ -3674,9 +3674,9 @@
       "dev": true
     },
     "node-abi": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.19.0.tgz",
-      "integrity": "sha512-rpKqVe24p9GvMTgtqUXdLR1WQJBGVlkYPU10qHKv9/1i9V/k04MmFLVK2WcHBf1WKKY+ZsdvARPi8F4tfJ4opA==",
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.30.0.tgz",
+      "integrity": "sha512-g6bZh3YCKQRdwuO/tSZZYJAw622SjsRfJ2X0Iy4sSOHZ34/sPPdVBn8fev2tj7njzLwuqPw9uMtGsGkO5kIQvg==",
       "dev": true,
       "requires": {
         "semver": "^5.4.1"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@electron-forge/maker-rpm": "6.0.0-beta.52",
     "@electron-forge/maker-squirrel": "6.0.0-beta.52",
     "@electron-forge/maker-zip": "6.0.0-beta.52",
-    "electron": "9.2.1",
+    "electron": "^13.1.1",
     "electron-icon-builder": "^1.0.2"
   }
 }


### PR DESCRIPTION
Bumps electron + node-abi to recent versions. This involves several major versions (electron's breaking changes can be seen [here](https://www.electronjs.org/docs/breaking-changes)), but given how simple the integration is atm, none of them should be relevant besides more secure defaults. Tested this out on a fork to make sure nothing in electron-forge broke as a result: https://github.com/seleb/twine-app-builder/actions/runs/912305284